### PR TITLE
fix pattern trim

### DIFF
--- a/Log/LogStatement.cpp
+++ b/Log/LogStatement.cpp
@@ -104,6 +104,7 @@ namespace Sys
                 delete []t;
                 index++;
             }
+            strcat(fP, nonPat + curStrIndex);
             delete [] nonPat;
             char *ret = createStr(finalStr);
             char *temp = addSpecialStr(ret, messageIndex, message, levelIndex, level.c_str());

--- a/LogTesting/LogStatementTest.cpp
+++ b/LogTesting/LogStatementTest.cpp
@@ -17,4 +17,11 @@ namespace LogTesting
         expectedMsg.append(".message is : message\n");
         EXPECT_STREQ(expectedMsg.c_str(), ls.getMessage(pm.getNecessaryData()).c_str());
     }
+    TEST(LogStatementTest, testPatternTrim)
+    {
+        PreMessage pm("@[msg].", "logname");
+        LogStatement ls(&pm, "message", String("test_level"));
+        String expextedMsg = String("message.\n");
+        EXPECT_STREQ(expextedMsg.c_str(), ls.getMessage(pm.getNecessaryData()).c_str());
+    }
 }


### PR DESCRIPTION
when the pattern ending with regular text(not special for the logger)
this text was trimming and not get logged.
Fixes #10 